### PR TITLE
restore the unmount slack on page transitions

### DIFF
--- a/src/App/ContentPortal.tsx
+++ b/src/App/ContentPortal.tsx
@@ -5,9 +5,17 @@ import { SwitchTransition, CSSTransition as CST } from 'react-transition-group'
 import { NOT_FOUND_NODE_REF, ROUTES } from '../routes'
 import './ContentPortal.scss'
 
-// The only definition of the transition duration. ContentPortal.scss reads it
+// The only definition of the fade duration. ContentPortal.scss reads it
 // through the custom property below rather than declaring its own copy.
 const TRANSITION_MS = 250
+
+// CSSTransition's timeout is not the fade length. It is when the transition is
+// declared over, and under unmountOnExit that is when the exiting node is torn
+// out. It has to outlast the fade: setting the two equal makes the unmount race
+// the fade's final frame, which shows up as a flash between pages. That is why
+// this is a separate number rather than TRANSITION_MS reused.
+const UNMOUNT_SLACK_MS = 50
+const TIMEOUT_MS = TRANSITION_MS + UNMOUNT_SLACK_MS
 
 // Custom properties are not part of the CSSProperties type, hence the cast.
 const TRANSITION_STYLE = {
@@ -27,7 +35,7 @@ export default function ContentPortal() {
         <CST
           key={loc.key}
           classNames="fade"
-          timeout={TRANSITION_MS}
+          timeout={TIMEOUT_MS}
           nodeRef={nodeRef}
           unmountOnExit
         >


### PR DESCRIPTION
The page-transition flash on the live site is a regression from #143.

`ContentPortal.scss` fades over 250ms. `CSSTransition`'s `timeout` was **300ms** before that PR — 50ms of deliberate slack. Consolidating the duration into a single `TRANSITION_MS` constant reused it for both, dropping the timeout to 250ms.

`timeout` is not the fade length. It is when react-transition-group declares the transition finished, and under `unmountOnExit` that is when the exiting node is removed. Equal to the fade duration, the unmount races the fade's final frame, so the node can disappear while it is still partly opaque — the flash.

The fix derives the timeout with the slack named explicitly, restoring 300ms while keeping the duration defined in one place:

```ts
const TRANSITION_MS = 250
const UNMOUNT_SLACK_MS = 50
const TIMEOUT_MS = TRANSITION_MS + UNMOUNT_SLACK_MS
```

No regression test. I tried two and threw both away: the node's measured lifetime is ~604ms fixed vs ~554ms regressed, because `SwitchTransition`'s out-in mode runs exit and enter in sequence, so any discriminating threshold has to sit between those two numbers and encodes library internals. Both weaker versions passed on the broken code, which is worse than no test. The constraint is documented in a comment instead.