### PR TITLE
gate the deploy on lint and tests, stop running them twice

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -7,8 +7,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Reused rather than duplicated: these are the same workflows the PR checks
+  # run. `needs:` only accepts jobs in this file, which is why they are pulled
+  # in with workflow_call instead of being depended on across workflows.
+  lint:
+    uses: ./.github/workflows/lint.yml
+  test:
+    uses: ./.github/workflows/test.yml
+
   build_and_deploy:
     name: Deploy
+    needs: [lint, test]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,11 @@
 name: Lint
 
+# No `push: branches: [master]`. The pull_request run already tests the merge
+# commit (refs/pull/N/merge), and on master this is invoked by the deploy
+# workflow via workflow_call, so master is still covered without running twice.
 on:
-  push:
-    branches: [master]
   pull_request:
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,11 @@
 name: Test
 
+# No `push: branches: [master]`. The pull_request run already tests the merge
+# commit (refs/pull/N/merge), and on master this is invoked by the deploy
+# workflow via workflow_call, so master is still covered without running twice.
 on:
-  push:
-    branches: [master]
   pull_request:
+  workflow_call:
   workflow_dispatch:
 
 # A new push to a PR branch cancels that PR's in-flight run rather than


### PR DESCRIPTION
Two problems, one change.

**The deploy was never gated.** `firebase-hosting-merge.yml` had no `needs:` and ran no tests, so on push to `master` all three workflows fired in parallel. The deploy did not wait for `Lint` or `Integration tests` and did not care what they said — a red build shipped to production, and the test job reported red afterwards.

**Lint and tests ran twice.** The `pull_request` event checks out `refs/pull/N/merge` — the PR already merged into `master` — so the post-merge run re-verified a commit that had effectively been verified.

Both are fixed by pulling the existing workflows in as reusable ones:

```yaml
jobs:
  lint:
    uses: ./.github/workflows/lint.yml
  test:
    uses: ./.github/workflows/test.yml
  build_and_deploy:
    needs: [lint, test]
```

`needs:` only accepts job IDs in the same file, so a cross-workflow dependency is not expressible; `workflow_call` is what makes `lint` and `test` jobs *of this workflow* while keeping a single definition of the steps. `push: branches: [master]` comes off both, since master is now covered once, as part of the deploy.

The check names PRs use (`Lint`, `Integration tests`) are unchanged, so branch protection can still reference them.

Note this PR cannot exercise the new wiring — the deploy workflow only fires on push to `master`. Validated with `actionlint` instead, which parses the reusable-workflow contract; confirmed it is real validation by pointing a job at a workflow lacking `workflow_call` and watching it fail with `"workflow_call" event trigger is not found`.